### PR TITLE
Feature/sdl 0192 button subscription response from hmi [internal review]

### DIFF
--- a/modules/connecttest.lua
+++ b/modules/connecttest.lua
@@ -188,7 +188,7 @@ function Test:initHMI()
 
   EXPECT_HMIEVENT(events.connectedEvent, "Connected websocket")
   :Do(function()
-      registerComponent("Buttons", {"Buttons.OnButtonSubscription"})
+      registerComponent("Buttons")
       registerComponent("TTS")
       registerComponent("VR")
       registerComponent("BasicCommunication",


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
Remove redundant registerComponent 'Buttons.OnButtonSubscription'
for testing feature "SDL-092 Button Subscription response from HMI"

### Changelog
 -  removed registerComponent 'Buttons.OnButtonSubscription'
